### PR TITLE
Rename host variables to source

### DIFF
--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -39,39 +39,39 @@ class RedisClient:
     def _settings_key(self, source):
         return self._prefixed_key(f"settings:{source}")
 
-    def _delete_target(self, host):
-        key = self._route_key(host)
+    def _delete_target(self, source):
+        key = self._route_key(source)
         self.client.delete(key)
     
-    def _delete_settings(self, host):
-        key = self._settings_key(host)
+    def _delete_settings(self, source):
+        key = self._settings_key(source)
         self.client.delete(key)
 
-    def _lookup_target(self, host, raise_exception=False):
-        key = self._route_key(host)
+    def _lookup_target(self, source, raise_exception=False):
+        key = self._route_key(source)
         target = self.client.get(key)
-        
+
         if target is None and raise_exception:
             raise exceptions.NotFound("Route not found.")
         
         return target
 
-    def _lookup_settings(self, host):
-        key = self._settings_key(host)
+    def _lookup_settings(self, source):
+        key = self._settings_key(source)
         return self.client.hgetall(key)
 
-    def lookup_hosts(self, pattern="*"):
+    def lookup_sources(self, pattern="*"):
         lookup_pattern = self._route_key(pattern)
         left_padding = len(lookup_pattern) - 1
         keys = self.client.keys(lookup_pattern)
         return [_str(key)[left_padding:] for key in keys]
     
-    def _set_target(self, host, target):
-        key = self._route_key(host)
-        self.client.set(key, target)
+    def _set_target(self, source, target, ttl=None):
+        key = self._route_key(source)
+        self.client.set(key, target, ex=ttl)
 
-    def _set_settings(self, host, settings):
-        key = self._settings_key(host)
+    def _set_settings(self, source, settings):
+        key = self._settings_key(source)
         self.client.hmset(key, settings)
     
     def _set_route(self, route: schemas.Route):
@@ -80,30 +80,30 @@ class RedisClient:
         self._set_settings(route.source, redis_data["settings"])
         return route
     
-    def get_route(self, host):
-        target = self._lookup_target(host, raise_exception=True)
-        settings = self._lookup_settings(host)
+    def get_route(self, source):
+        target = self._lookup_target(source, raise_exception=True)
+        settings = self._lookup_settings(source)
         route = schemas.Route.from_redis({
-            "source": host,
+            "source": source,
             "target": target,
             "settings": settings
         })
         return route
 
     def list_routes(self):
-        hosts = self.lookup_hosts()
-        routes = [self.get_route(host) for host in hosts]
+        sources = self.lookup_sources()
+        routes = [self.get_route(source) for source in sources]
         return routes
     
     def create_route(self, data: dict):
         route = schemas.Route.validate(data)
         return self._set_route(route)
     
-    def update_route(self, host: str, data: dict):
-        data["source"] = host
+    def update_route(self, source: str, data: dict):
+        data["source"] = source
         route = schemas.Route.validate(data)
         return self._set_route(route)
 
-    def delete_route(self, host: str):
-        self._delete_target(host)
-        self._delete_settings(host)
+    def delete_route(self, source: str):
+        self._delete_target(source)
+        self._delete_settings(source)

--- a/ceryx/nginx/lualib/ceryx/routes.lua
+++ b/ceryx/nginx/lualib/ceryx/routes.lua
@@ -16,7 +16,7 @@ end
 
 function getTargetForSource(source, redisClient)
     -- Construct Redis key and then
-    -- try to get target for host
+    -- try to get target for source
     local key = getRouteKeyForSource(source)
     local target, _ = redisClient:get(key)
 
@@ -69,7 +69,7 @@ function getRouteForSource(source)
         if targetIsInValid(route.target) then
             return nil
         end
-        cache:set(host, res, 5)
+        cache:set(source, res, 5)
         ngx.log(ngx.DEBUG, "Caching from " .. source .. " to " .. route.target .. " for 5 seconds.")
     end
 


### PR DESCRIPTION
In preparation of a larger merge request which adds more ways on
source matching the variables indicating a host match are renamed to the
more generic term source.