### PR TITLE
Add request_uri to possible sources

### DIFF
--- a/ceryx/nginx/lualib/router.lua
+++ b/ceryx/nginx/lualib/router.lua
@@ -5,17 +5,21 @@ local utils = require "ceryx.utils"
 local redisClient = redis:client()
 
 local host = ngx.var.host
+local request_uri = ngx.var.request_uri:sub(2)
 local cache = ngx.shared.ceryx
 
 local is_not_https = (ngx.var.scheme ~= "https")
 
-function formatTarget(target)
+function formatTargetHostSource(target)
     target = utils.ensure_protocol(target)
     target = utils.ensure_no_trailing_slash(target)
-
     return target .. ngx.var.request_uri
 end
 
+function formatTargetRequestUriSource(target)
+    target = utils.ensure_protocol(target)
+    return target
+end
 
 function redirect(source, target, headers)
     ngx.log(ngx.INFO, "Redirecting request for " .. source)
@@ -35,8 +39,6 @@ end
 
 function routeRequest(source, target, mode, headers)
     ngx.log(ngx.DEBUG, "Received " .. mode .. " routing request from " .. source .. " to " .. target)
-
-    target = formatTarget(target)
 
     if mode == "redirect" then
         return redirect(source, target, headers)
@@ -60,13 +62,19 @@ if is_not_https then
     end
 end
 
-ngx.log(ngx.INFO, "HOST " .. host)
+ngx.log(ngx.INFO, "Try host route for " .. host)
 local route = routes.getRouteForSource(host)
 
-if route == nil then
-    ngx.log(ngx.INFO, "No $wildcard target configured for fallback. Exiting with Bad Gateway.")
-    return ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
+if route ~= nil then
+    return routeRequest(host, formatTargetHostSource(route.target), route.mode, route.headers)
 end
 
--- Save found key to local cache for 5 seconds
-routeRequest(host, route.target, route.mode, route.headers)
+ngx.log(ngx.INFO, "Try request_uri route for " .. request_uri)
+route = routes.getRouteForSource(request_uri)
+
+if route ~= nil then
+    return routeRequest(request_uri, formatTargetRequestUriSource(route.target), route.mode, route.headers)
+end
+
+ngx.log(ngx.INFO, "No $wildcard target configured for fallback. Exiting with Bad Gateway.")
+ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)


### PR DESCRIPTION
The proxy now first tries to find a matching route based on the host and
if this does not yield a result it will next try to find a route based
on the request_uri (without leading slash).

This commit depends on the presence of feature/headers.