### PR TITLE
Add ttl to routes

### DIFF
--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -76,7 +76,7 @@ class RedisClient:
     
     def _set_route(self, route: schemas.Route):
         redis_data = route.to_redis()
-        self._set_target(route.source, redis_data["target"])
+        self._set_target(route.source, redis_data["target"], route.settings.get("ttl"))
         self._set_settings(route.source, redis_data["settings"])
         return route
     

--- a/api/ceryx/schemas.py
+++ b/api/ceryx/schemas.py
@@ -15,6 +15,14 @@ def redis_to_boolean(value):
     return True if value == "1" else False
 
 
+def integer_to_redis(value: int):
+    return str(value)
+
+
+def redis_to_integer(value):
+    return int(value)
+
+
 def ensure_string(value):
     redis_value = (
         None if value is None
@@ -30,6 +38,9 @@ def value_to_redis(field, value):
     if isinstance(field, typesystem.Reference):
         return field.target.validate(value).to_redis()
 
+    if isinstance(field, typesystem.Integer):
+        return integer_to_redis(value)
+
     return ensure_string(value)
 
 
@@ -39,6 +50,9 @@ def redis_to_value(field, redis_value):
     
     if isinstance(field, typesystem.Reference):
         return field.target.from_redis(redis_value)
+
+    if isinstance(field, typesystem.Integer):
+        return redis_to_integer(redis_value)
 
     return ensure_string(redis_value)
 
@@ -69,6 +83,7 @@ class Settings(BaseSchema):
         ),
         default="proxy",
     )
+    ttl = typesystem.Integer(allow_null=True)
     certificate_path = typesystem.String(allow_null=True)
     key_path = typesystem.String(allow_null=True)
 


### PR DESCRIPTION
It is now possible to add a ttl setting in seconds to the settings of a
route which will set a redis EXPIRE tag on the respective route.

The default is persistent.