### PR TITLE
Fix responder error on missing default route path

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -8,7 +8,7 @@ api = responder.API()
 client = RedisClient.from_config()
 
 
-@api.route(default=True)
+@api.route("/", default=True)
 def default(req, resp):
     if not req.url.path.endswith("/"):
         api.redirect(resp, f"{req.url.path}/")


### PR DESCRIPTION
In newer versions or some environments it may occur that the responder
API complains about a missing, explicit default route key.