### PR TITLE
Set http to https protocol if unsure

### DIFF
--- a/ceryx/nginx/lualib/ceryx/utils.lua
+++ b/ceryx/nginx/lualib/ceryx/utils.lua
@@ -18,7 +18,7 @@ end
 
 function exports.ensure_protocol(target)
     if not starts_with_protocol(target) then
-        return "http://" .. target
+        return "https://" .. target
     end
 
     return target


### PR DESCRIPTION
It is better to asume https protocol if no protocol is present.

If http is desired, it should be stated explicitly. This is important
for environments where targets point to external resources.

THIS IS A BREAKING CHANGE.