### PR TITLE
Add explicit remove of hash before set

### DIFF
--- a/api/ceryx/db.py
+++ b/api/ceryx/db.py
@@ -71,6 +71,7 @@ class RedisClient:
         self.client.set(key, target)
 
     def _set_settings(self, host, settings):
+        self._delete_settings(host)
         key = self._settings_key(host)
         self.client.hmset(key, settings)
     


### PR DESCRIPTION
When using redis EXPIRE or any other automated cleaning utility it may
happen that a hash is not fully removed. If a new hash is set at the
same key and there are null values the old stored values may be reused.